### PR TITLE
👷 Set `PYTHONWARNDEFAULTENCODING` in GitHub Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,9 @@ on:
       - '**'
   pull_request: {}
 
+env:
+  PYTHONWARNDEFAULTENCODING: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix #91 

This merge request sets the `PYTHONWARNDEFAULTENCODING` variable in the GitHub workflow per the documentation at https://docs.github.com/en/actions/learn-github-actions/variables.

I've chosen to set `PYTHONWARNDEFAULTENCODING` to the value `true` to ensure it is clear that this is enabling the feature. With that said, https://docs.python.org/3/library/io.html#opt-in-encodingwarning does not indicate that there is a value of the environment variable that would disable this, so I understand if a different value would be preferred.