### PR TITLE
Ensure that warnings are treated as errors and fix encoding errors

### DIFF
--- a/bump_pydantic/main.py
+++ b/bump_pydantic/main.py
@@ -82,7 +82,7 @@ def main(
             progress.advance(task)
 
             # Visitor logic
-            code = Path(filename).read_text()
+            code = Path(filename).read_text(encoding="utf8")
             module = cst.parse_module(code)
             module_and_package = calculate_module_and_package(str(package), filename)
 

--- a/bump_pydantic/main.py
+++ b/bump_pydantic/main.py
@@ -109,7 +109,7 @@ def main(
 
     codemods = gather_codemods(disabled=disable)
 
-    log_fp = log_file.open("a+")
+    log_fp = log_file.open("a+", encoding="utf8")
     partial_run_codemods = functools.partial(run_codemods, codemods, metadata_manager, scratch, package, diff)
     with Progress(*Progress.get_default_columns(), transient=True) as progress:
         task = progress.add_task(description="Executing codemods...", total=len(files))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ xfail_strict = true
 filterwarnings = [
     # Turn warnings that aren't filtered into exceptions
     "error",
+    "ignore::pytest.PytestUnraisableExceptionWarning"
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ target-version = 'py38'
 
 [tool.pytest.ini_options]
 xfail_strict = true
+filterwarnings = [
+    # Turn warnings that aren't filtered into exceptions
+    "error",
+]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Sorry, I had meant to originally create this as a draft / against my fork, but it ended up here.

This merge request is a follow-up to https://github.com/pydantic/bump-pydantic/pull/93 which fixes:

1. That warning are treated as errors
2. That the encoding errors identified in the tests are fixed.

This merge request opens encoding as `"utf8"` in the mypy visitor to align with the default encoding of all python files as of Python 3. Since the logfile is controlled by bump-pydantic, I used `utf8` as well for consistency with the python language files.