### PR TITLE
♻️ Do not convert `constr` to `Annotated`

### DIFF
--- a/bump_pydantic/codemods/con_func.py
+++ b/bump_pydantic/codemods/con_func.py
@@ -57,6 +57,10 @@ class ConFuncCallCommand(VisitorBasedCodemodCommand):
             func_name = cast(str, annotation.func.attr.value)  # type: ignore
         type_name = MAP_FUNC_TO_TYPE[func_name]
 
+        # TODO: When FastAPI supports Pydantic 2.0.4+, remove the conditional below.
+        if func_name == "constr":
+            return updated_node
+
         needed_import = MAP_TYPE_TO_NEEDED_IMPORT.get(type_name)
         if needed_import is not None:
             AddImportsVisitor.add_needed_import(context=self.context, **needed_import)  # type: ignore[arg-type]
@@ -82,12 +86,13 @@ class ConFuncCallCommand(VisitorBasedCodemodCommand):
         annotation = cst.Annotation(annotation=annotated)  # type: ignore[assignment]
         return updated_node.with_changes(annotation=annotation)
 
+    # TODO: When FastAPI supports Pydantic 2.0.4+, remove the comments below.
     @m.leave(CONSTR_CALL)
     def leave_constr_call(self, original_node: cst.Call, updated_node: cst.Call) -> cst.Call:
         self._remove_import(original_node.func)
-        AddImportsVisitor.add_needed_import(context=self.context, module="pydantic", obj="StringConstraints")
+        # AddImportsVisitor.add_needed_import(context=self.context, module="pydantic", obj="StringConstraints")
         return updated_node.with_changes(
-            func=cst.Name("StringConstraints"),
+            # func=cst.Name("StringConstraints"),
             args=[
                 arg if arg.keyword and arg.keyword.value != "regex" else arg.with_changes(keyword=cst.Name("pattern"))
                 for arg in updated_node.args

--- a/tests/integration/cases/con_func.py
+++ b/tests/integration/cases/con_func.py
@@ -23,14 +23,14 @@ cases = [
         expected=File(
             "con_func.py",
             content=[
-                "from pydantic import Field, StringConstraints, BaseModel",
+                "from pydantic import Field, BaseModel, constr",
                 "from decimal import Decimal",
                 "from typing import List, Set",
                 "from typing_extensions import Annotated",
                 "",
                 "",
                 "class Potato(BaseModel):",
-                "    a: Annotated[str, StringConstraints(pattern='[a-z]+')]",
+                "    a: constr(pattern='[a-z]+')",
                 "    b: Annotated[List[int], Field(min_length=1, max_length=10)]",
                 "    c: Annotated[int, Field(gt=0, lt=10)]",
                 "    d: Annotated[bytes, Field(min_length=1, max_length=10)]",

--- a/tests/unit/test_con_func.py
+++ b/tests/unit/test_con_func.py
@@ -1,3 +1,4 @@
+import pytest
 from libcst.codemod import CodemodTest
 
 from bump_pydantic.codemods.con_func import ConFuncCallCommand
@@ -8,6 +9,7 @@ class TestFieldCommand(CodemodTest):
 
     maxDiff = None
 
+    @pytest.mark.xfail(reason="Annotated is not supported yet!")
     def test_constr_to_annotated(self) -> None:
         before = """
         from pydantic import BaseModel, constr
@@ -24,6 +26,7 @@ class TestFieldCommand(CodemodTest):
         """
         self.assertCodemod(before, after)
 
+    @pytest.mark.xfail(reason="Annotated is not supported yet!")
     def test_pydantic_constr_to_annotated(self) -> None:
         before = """
         import pydantic


### PR DESCRIPTION
This is necessary until FastAPI supports Pydantic 2.0.4, and we actually release Pydantic 2.0.4.