### PR TITLE
Add support for non-call @root_validator

### DIFF
--- a/bump_pydantic/codemods/validator.py
+++ b/bump_pydantic/codemods/validator.py
@@ -168,10 +168,11 @@ class ValidatorCodemod(VisitorBasedCodemodCommand):
         AddImportsVisitor.add_needed_import(self.context, "pydantic", new_name)
         if m.matches(node.decorator, m.Call()):
             decorator = node.decorator.with_changes(func=cst.Name(new_name), args=self._args)
-        elif m.matches(node.decorator, m.Name()):  # @root_validator (Name, not Call) -> @model_validator(...) (Call)
-            decorator = cst.Call(func=cst.Name(new_name), args=self._args)
         else:
-            raise RuntimeError("decorator as attribute is not implemented yet.")  # this should never happen ATM
+            # Assuming node.decorator matches Name()
+            # (once ROOT_VALIDATOR_DECORATOR supports Attribute() this needs a separate case).
+            # Changing `@root_validator` (Name, not Call) into `@model_validator(...)` (Call)
+            decorator = cst.Call(func=cst.Name(new_name), args=self._args)
         return node.with_changes(decorator=decorator)
 
 

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -319,7 +319,6 @@ class TestValidatorCommand(CodemodTest):
         """
         self.assertCodemod(before, after)
 
-    @pytest.mark.xfail(reason="Not implemented yet.")
     def test_root_validator_as_cst_name(self) -> None:
         before = """
         import typing as t
@@ -338,14 +337,15 @@ class TestValidatorCommand(CodemodTest):
         after = """
         import typing as t
 
-        from pydantic import BaseModel, model_validator
+        from pydantic import model_validator, BaseModel
 
 
         class Potato(BaseModel):
             name: str
             dialect: str
 
-            @model_validator
+            @model_validator(mode="after")
+            @classmethod
             def _normalize_fields(cls, values: t.Dict[str, t.Any]) -> t.Dict[str, t.Any]:
                 return values
         """


### PR DESCRIPTION
In Pydantic v1 having a plain decorator like `@root_validator` (without `()`) was common and worked fine.

In v2, `@model_validator` needs a `mode` argument.

Add a test and adjust implementation, so that the program replaces
```py
@root_validator
def foo(cls, values):
    ...
```
with:
```py
@model_validator(mode="after")
@classmethod
def foo(cls, values):
    ...
```

---

The implementation maybe is not beautiful, but seems to work 😅.

While working on this I noticed that having a `@model_validator()` (without args) in v2 produces an error. One has to provide the `mode` arg.
I can open a separate PR for this,
but this change most likely will need a separate `visit` method
for `ROOT_VALIDATOR_DECORATOR`,
because `mode` in `field_validator` can be omitted.
