### PR TITLE
:sparkles: only add classmethod decorator if it doesn't already exist with validator

### DIFF
--- a/bump_pydantic/codemods/validator.py
+++ b/bump_pydantic/codemods/validator.py
@@ -140,6 +140,13 @@ class ValidatorCodemod(VisitorBasedCodemodCommand):
             self._should_add_comment = False
             return updated_node
 
+        # Check if a classmethod decorator already exists
+        if any(
+            m.matches(decorator, m.Decorator(decorator=m.Name("classmethod"))) for decorator in updated_node.decorators
+        ):
+            return updated_node  # If it already exists, return the node as is
+
+        # If it doesn't exist, add the classmethod decorator
         classmethod_decorator = cst.Decorator(decorator=cst.Name("classmethod"))
         return updated_node.with_changes(decorators=[*updated_node.decorators, classmethod_decorator])
 


### PR DESCRIPTION
I ran bump-pydantic on one of our projects, and it has auto-converted the following, from:
```py
    @root_validator(pre=True)
    @classmethod
```
to:
```py
    @model_validator(mode="before")
    @classmethod
    @classmethod
```

This PR amends this behavior to only add the classmethod decorator if it doesn't already exist.

To test, I ran `pip install /path/to/my/fork`, and ran `bump-pydantic .` again. Now the extra decorator won't be added unnecessarily