### PR TITLE
Convert `example` parameter into `examples` on `Field`

### DIFF
--- a/bump_pydantic/codemods/field.py
+++ b/bump_pydantic/codemods/field.py
@@ -125,7 +125,7 @@ class FieldCodemod(VisitorBasedCodemodCommand):
                             value = cst.Name("False")
                     if arg.keyword.value == "example":
                         # The example keyword is now a list, `examples`.
-                        value = cst.List([arg.value])
+                        value = cst.List([cst.Element(arg.value)])
                 new_arg = arg.with_changes(keyword=arg.keyword.with_changes(value=keyword), value=value)  # type: ignore
                 new_args.append(new_arg)  # type: ignore
             else:

--- a/bump_pydantic/codemods/field.py
+++ b/bump_pydantic/codemods/field.py
@@ -9,6 +9,7 @@ RENAMED_KEYWORDS = {
     "min_items": "min_length",
     "max_items": "max_length",
     "allow_mutation": "frozen",
+    "example": "examples",
     "regex": "pattern",
     # NOTE: This is only for BaseSettings.
     "env": "validation_alias",
@@ -115,12 +116,16 @@ class FieldCodemod(VisitorBasedCodemodCommand):
             if m.matches(arg, m.Arg(keyword=m.Name())):
                 keyword = RENAMED_KEYWORDS.get(arg.keyword.value, arg.keyword.value)  # type: ignore
                 value = arg.value
-                # The `allow_mutation` keyword argument is a special case. It's the negative of `frozen`.
-                if arg.keyword and arg.keyword.value == "allow_mutation":
-                    if m.matches(arg.value, m.Name(value="False")):
-                        value = cst.Name("True")
-                    elif m.matches(arg.value, m.Name(value="True")):
-                        value = cst.Name("False")
+                if arg.keyword:
+                    if arg.keyword.value == "allow_mutation":
+                        # The `allow_mutation` keyword is the negative of `frozen`.
+                        if m.matches(arg.value, m.Name(value="False")):
+                            value = cst.Name("True")
+                        elif m.matches(arg.value, m.Name(value="True")):
+                            value = cst.Name("False")
+                    if arg.keyword.value == "example":
+                        # The example keyword is now a list, `examples`.
+                        value = cst.List([arg.value])
                 new_arg = arg.with_changes(keyword=arg.keyword.with_changes(value=keyword), value=value)  # type: ignore
                 new_args.append(new_arg)  # type: ignore
             else:

--- a/tests/unit/test_field.py
+++ b/tests/unit/test_field.py
@@ -136,3 +136,18 @@ class TestFieldCommand(CodemodTest):
             potato: Annotated[List[int], Field(..., min_length=1, max_length=10)]
         """
         self.assertCodemod(before, after)
+
+    def test_example_list(self) -> None:
+        before = """
+        from pydantic import BaseSettings, Field
+
+        class Settings(BaseSettings):
+            potato: int = Field(..., example=1)
+        """
+        after = """
+        from pydantic import BaseSettings, Field
+
+        class Settings(BaseSettings):
+            potato: int = Field(..., examples=[1,])
+        """
+        self.assertCodemod(before, after)

--- a/tests/unit/test_field.py
+++ b/tests/unit/test_field.py
@@ -148,6 +148,6 @@ class TestFieldCommand(CodemodTest):
         from pydantic import BaseSettings, Field
 
         class Settings(BaseSettings):
-            potato: int = Field(..., examples=[1,])
+            potato: int = Field(..., examples=[1])
         """
         self.assertCodemod(before, after)


### PR DESCRIPTION
This codemod is intended to convert an example to a single element list of examples. 

~When I tried to run it however, I get the following exception from `libcst`. I presume it is because there is a bug with the list construct, but it could be a coding mistake on my part.~

Thanks Brian for the suggestion that fixed this PR.

```
self = Integer(
    value='1',
    lpar=[],
    rpar=[],
)
state = CodegenState(default_indent='    ', default_newline='\n', provider=None, indent_tokens=['    '], tokens=['from', ' ', ...'int', ' ', '=', ' ', 'Field', '', '(', '', '', '', '...', '', ',', ' ', '', '', '', 'examples', '', '=', '', '[', ''])
kwargs = {'default_comma': False, 'default_comma_whitespace': True}

    def _codegen(self, state: CodegenState, **kwargs: Any) -> None:
        state.before_codegen(self)
>       self._codegen_impl(state, **kwargs)
E       TypeError: _codegen_impl() got an unexpected keyword argument 'default_comma'

../../.pyenv/versions/3.9.16/lib/python3.9/site-packages/libcst/_nodes/base.py:300: TypeError
- generated xml file: /var/folders/sh/fdr554614wlb2s12tx1bw8wm0000gn/T/tmp-78979sbVUwmyuq3zy.xml -

```

EDIT by @Kludex:
- Closes #121