### PR TITLE
Add default none for Field correctly

### DIFF
--- a/bump_pydantic/codemods/add_default_none.py
+++ b/bump_pydantic/codemods/add_default_none.py
@@ -86,10 +86,10 @@ class AddDefaultNoneCommand(VisitorBasedCodemodCommand):
                 assert isinstance(updated_node.value, cst.Call)
                 if updated_node.value.args:
                     arg = updated_node.value.args[0]
-                    if (arg.keyword is None or arg.keyword.value == "default") and m.matches(arg.value, m.Ellipsis()):
+                    if arg.keyword and arg.keyword.value != "default":
                         updated_node = updated_node.with_changes(
                             value=updated_node.value.with_changes(
-                                args=[arg.with_changes(value=cst.Name("None")), *updated_node.value.args[1:]]
+                                args=[cst.Arg(value=cst.Name("None")), *updated_node.value.args]
                             )
                         )
                 # This is the case where `Field` is called without any arguments e.g. `Field()`.

--- a/tests/integration/cases/add_none.py
+++ b/tests/integration/cases/add_none.py
@@ -38,10 +38,10 @@ cases = [
                 "    c: Union[int, None] = None",
                 "    d: Any = None",
                 "    e: Dict[str, str]",
-                "    f: Optional[int] = Field(None, lt=10)",
+                "    f: Optional[int] = Field(..., lt=10)",
                 "    g: Optional[int] = Field(None)",
-                "    h: Optional[int] = Field(None)",
-                "    i: Optional[int] = Field(default_factory=lambda: None)",
+                "    h: Optional[int] = Field(...)",
+                "    i: Optional[int] = Field(None, default_factory=lambda: None)",
             ],
         ),
     )

--- a/tests/unit/test_add_default_none.py
+++ b/tests/unit/test_add_default_none.py
@@ -148,3 +148,32 @@ class Potato(BaseModel):
 """
         )
         assert module.code == expected
+
+    def test_with_field(self) -> None:
+        module = self.add_default_none(
+            "some/test/module.py",
+            """
+            from pydantic import BaseModel, Field
+            from typing import Optional
+
+            class Foo(BaseModel):
+                a: Optional[int] = Field()
+                c: Optional[int] = Field(...)
+                d: Optional[int] = Field(description="spam")
+                e: Optional[int] = Field(default=..., description="spam")
+                f: Optional[int] = Field(default=None, description="spam")
+            """,
+        )
+        expected = textwrap.dedent(
+            """from pydantic import BaseModel, Field
+from typing import Optional
+
+class Foo(BaseModel):
+    a: Optional[int] = Field(None)
+    c: Optional[int] = Field(...)
+    d: Optional[int] = Field(None, description="spam")
+    e: Optional[int] = Field(default=..., description="spam")
+    f: Optional[int] = Field(default=None, description="spam")
+"""
+        )
+        assert module.code == expected


### PR DESCRIPTION
None should be added if nothing was specified for `default` of Field if I understood correctly.
This PR is to fix https://github.com/pydantic/bump-pydantic/issues/113 as well.

Before:
```python
class Foo(BaseModel):
    a: Optional[int] = Field() # here
    b: Optional[int] = Field(...)
    c: Optional[int] = Field(None, description="spam")
    d: Optional[int] = Field(description="spam") # here
    e: Optional[int] = Field(default=..., description="spam")
    f: Optional[int] = Field(default=None, description="spam")
```

After:
```python
class Foo(BaseModel):
    a: Optional[int] = Field(None) # here
    b: Optional[int] = Field(...)
    c: Optional[int] = Field(None, description="spam")
    d: Optional[int] = Field(None, description="spam") # here
    e: Optional[int] = Field(default=..., description="spam")
    f: Optional[int] = Field(default=None, description="spam")
```