### PR TITLE
Added license information to classifiers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
+  "License :: OSI Approved :: MIT License",
   "Framework :: Pydantic",
+  "Environment :: Console",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Topic :: Internet",
 ]
 dependencies = ["typer>=0.7.0", "libcst", "rich", "typing_extensions"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Framework :: Pydantic",
   "Environment :: Console",
-  "Topic :: Software Development :: Libraries :: Python Modules",
-  "Topic :: Internet",
+  "Topic :: Software Development :: Code Generators",
 ]
 dependencies = ["typer>=0.7.0", "libcst", "rich", "typing_extensions"]
 


### PR DESCRIPTION
First PR in github, so please pardon me if I missed something.
This added the common license classifiers which should hopefully help with license detection by 3rd party tools.