### PR TITLE
Do not duplicate classmethod when replacing validators

### DIFF
--- a/bump_pydantic/codemods/validator.py
+++ b/bump_pydantic/codemods/validator.py
@@ -142,8 +142,10 @@ class ValidatorCodemod(VisitorBasedCodemodCommand):
             self._should_add_comment = False
             return updated_node
 
-        classmethod_decorator = cst.Decorator(decorator=cst.Name("classmethod"))
-        return updated_node.with_changes(decorators=[*updated_node.decorators, classmethod_decorator])
+        if not any(m.matches(d, m.Decorator(decorator=m.Name("classmethod"))) for d in updated_node.decorators):
+            classmethod_decorator = cst.Decorator(decorator=cst.Name("classmethod"))
+            updated_node = updated_node.with_changes(decorators=[*updated_node.decorators, classmethod_decorator])
+        return updated_node
 
     def _decorator_with_leading_comment(self, node: cst.Decorator, comment: str) -> cst.Decorator:
         return node.with_changes(

--- a/tests/unit/test_validator.py
+++ b/tests/unit/test_validator.py
@@ -278,6 +278,39 @@ class TestValidatorCommand(CodemodTest):
         """
         self.assertCodemod(before, after)
 
+    def test_replace_validator_with_existing_classmethod(self) -> None:
+        before = """
+        from pydantic import validator
+
+
+        class Potato(BaseModel):
+            name: str
+            dialect: str
+
+            @validator("name", "dialect")
+            @classmethod
+            def _string_validator(cls, v: t.Any) -> t.Optional[str]:
+                if isinstance(v, exp.Expression):
+                    return v.name.lower()
+                return str(v).lower() if v is not None else None
+        """
+        after = """
+        from pydantic import field_validator
+
+
+        class Potato(BaseModel):
+            name: str
+            dialect: str
+
+            @field_validator("name", "dialect")
+            @classmethod
+            def _string_validator(cls, v: t.Any) -> t.Optional[str]:
+                if isinstance(v, exp.Expression):
+                    return v.name.lower()
+                return str(v).lower() if v is not None else None
+        """
+        self.assertCodemod(before, after)
+
     @pytest.mark.xfail(reason="Not implemented yet")
     def test_import_pydantic(self) -> None:
         before = """


### PR DESCRIPTION
If a validator is already decorated with `classmethod` we should not duplicate the decorator.