### PR TITLE
json_encoders is back

### DIFF
--- a/bump_pydantic/codemods/replace_config.py
+++ b/bump_pydantic/codemods/replace_config.py
@@ -23,7 +23,6 @@ REMOVED_KEYS = [
     "underscore_attrs_are_private",
     "json_loads",
     "json_dumps",
-    "json_encoders",
     "copy_on_model_validation",
     "post_init_call",
 ]


### PR DESCRIPTION
This is supported again in Pydantic2: https://github.com/pydantic/pydantic/pull/6811