### PR TITLE
Preserve line break codes

### DIFF
--- a/bump_pydantic/main.py
+++ b/bump_pydantic/main.py
@@ -182,7 +182,7 @@ def run_codemods(
         context.scratch.update(scratch)
 
         file_path = Path(filename)
-        with file_path.open("r+", encoding="utf-8") as fp:
+        with file_path.open("r+", encoding="utf-8", newline="") as fp:
             code = fp.read()
             fp.seek(0)
 


### PR DESCRIPTION
Ensure that bump-pydantic command does not change the newline code.